### PR TITLE
Add sortable pokemon stats section

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,29 @@
             </div>
         </section>
 
+        <!-- Stats -->
+        <section class="stats-section">
+            <h2><i class="fas fa-chart-bar"></i> Stats</h2>
+            <div class="stats-controls">
+                <label for="stat-select">Compare by:</label>
+                <select id="stat-select">
+                    <option value="hp">HP</option>
+                    <option value="attack">Attack</option>
+                    <option value="defense">Defense</option>
+                    <option value="special-attack">Sp. Atk</option>
+                    <option value="special-defense">Sp. Def</option>
+                    <option value="speed" selected>Speed</option>
+                </select>
+                <label class="toggle">
+                    <input type="checkbox" id="stat-order-toggle" checked>
+                    <span>Show highest first</span>
+                </label>
+            </div>
+            <div id="stats-list" class="stats-list">
+                <!-- Stats rows injected here -->
+            </div>
+        </section>
+
         <!-- Battle Analysis -->
         <section class="battle-section">
             <h2><i class="fas fa-fist-raised"></i> Battle Analysis</h2>


### PR DESCRIPTION
Add the HTML structure for the new 'Stats' section to the team builder page, enabling users to compare and sort their team's stats.

---
<a href="https://cursor.com/background-agent?bcId=bc-94f20ed5-3466-4bf4-a366-54ce9c71876f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94f20ed5-3466-4bf4-a366-54ce9c71876f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

